### PR TITLE
Add support for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ filetype.
 Below is a list of sensible patterns for different filetypes:
 
 ```vim
-autocmd FileType c    let b:printf_pattern = 'fprintf(stderr, "%d\n", %s);'
-autocmd FileType go   let b:printf_pattern = 'fmt.Printf("%v\n", %s)'
-autocmd FileType ruby let b:printf_pattern = 'printf("%p\n", %s)'
-autocmd FileType vim  let b:printf_pattern = 'echom printf("%s", %s)'
+autocmd FileType c      let b:printf_pattern = 'fprintf(stderr, "%d\n", %s);'
+autocmd FileType go     let b:printf_pattern = 'fmt.Printf("%v\n", %s)'
+autocmd FileType python let b:printf_pattern = 'print("%{}".format(%s))'
+autocmd FileType ruby   let b:printf_pattern = 'printf("%p\n", %s)'
+autocmd FileType vim    let b:printf_pattern = 'echom printf("%s", %s)'
 ```
 
 See the [documentation] for further reference on how the pattern is interpreted.

--- a/doc/printf.txt
+++ b/doc/printf.txt
@@ -53,10 +53,11 @@ Since |b:printf_pattern| is a |buffer-variable| the pattern can be altered
 for a given |FileType|. Below is a list of sensible patterns for different
 filetypes:
 
-	au FileType c    let b:printf_pattern = 'fprintf(stderr, "%d\n", %s);'
-	au FileType go   let b:printf_pattern = 'fmt.Printf("%v\n", %s)'
-	au FileType ruby let b:printf_pattern = 'printf("%p\n", %s)'
-	au FileType vim  let b:printf_pattern = 'echom printf("%s", %s)'
+	au FileType c      let b:printf_pattern = 'fprintf(stderr, "%d\n", %s);'
+	au FileType go     let b:printf_pattern = 'fmt.Printf("%v\n", %s)'
+	au FileType python let b:printf_pattern = 'print("%{}".format(%s))'
+	au FileType ruby   let b:printf_pattern = 'printf("%p\n", %s)'
+	au FileType vim    let b:printf_pattern = 'echom printf("%s", %s)'
 
 =============================================================================
 3. Delimiter					*b:printf_delim*

--- a/doc/printf.txt
+++ b/doc/printf.txt
@@ -5,6 +5,7 @@ Version:	0.2.1
 
 1. Printf	|printf|
 2. Pattern	|b:printf_pattern|
+3. Delimiter	|b:printf_delim|
 
 =============================================================================
 1. Printf					*printf*
@@ -56,5 +57,14 @@ filetypes:
 	au FileType go   let b:printf_pattern = 'fmt.Printf("%v\n", %s)'
 	au FileType ruby let b:printf_pattern = 'printf("%p\n", %s)'
 	au FileType vim  let b:printf_pattern = 'echom printf("%s", %s)'
+
+=============================================================================
+3. Delimiter					*b:printf_delim*
+
+The delimiter, defaults to "=", used to join a token and directive can be
+specified using the |b:buffer-variable| named |b:printf_delim|. Example using
+another delimiter for Python:
+
+	au FileType python let b:printf_delim = ': '
 
   vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/printf.vim
+++ b/plugin/printf.vim
@@ -28,6 +28,14 @@ function! s:escape(str, chars) abort
   return s
 endfunction
 
+function! s:formatdirective(str) abort
+  if a:str == '%{}'
+    return a:str[1:]
+  else
+    return a:str
+  endif
+endfunction
+
 function! s:split(str) abort
   let str = a:str
   let parts = []
@@ -53,9 +61,9 @@ endfunction
 function! s:printf() abort
   let pattern = getbufvar('%', 'printf_pattern')
   if empty(pattern) | let pattern = 'printf("%d\n", %s);' | endif
-  let directive = matchstr(pattern, '%\(\w\|\.\)\+')
+  let directive = matchstr(pattern, '%\(\w\|\.\|{\|}\)\+')
 
-  let [prefix, middle, suffix] = split(pattern, '%\(\w\|\.\)\+', 1)
+  let [prefix, middle, suffix] = split(pattern, '%\(\w\|\.\|{\|}\)\+')
 
   " If the directive is wrapped in string quotes, escape the quote character.
   let esc = ''
@@ -65,6 +73,7 @@ function! s:printf() abort
   let indent = matchstr(getline('.'), '^\s\+')
   let line = substitute(getline('.'), indent, '', '')
   if len(line) == 0 | return | endif
+  let directive = s:formatdirective(directive)
   let format = join(map(s:split(line), 's:escape(v:val, esc) . "=" . directive'), ', ')
   call setline('.', indent . prefix . format . middle . line . suffix)
   normal! ^f%

--- a/plugin/printf.vim
+++ b/plugin/printf.vim
@@ -61,6 +61,9 @@ endfunction
 function! s:printf() abort
   let pattern = getbufvar('%', 'printf_pattern')
   if empty(pattern) | let pattern = 'printf("%d\n", %s);' | endif
+  let delim = getbufvar('%', 'printf_delim')
+  if empty(delim) | let delim = '=' | endif
+
   let directive = matchstr(pattern, '%\(\w\|\.\|{\|}\)\+')
 
   let [prefix, middle, suffix] = split(pattern, '%\(\w\|\.\|{\|}\)\+')
@@ -74,7 +77,7 @@ function! s:printf() abort
   let line = substitute(getline('.'), indent, '', '')
   if len(line) == 0 | return | endif
   let directive = s:formatdirective(directive)
-  let format = join(map(s:split(line), 's:escape(v:val, esc) . "=" . directive'), ', ')
+  let format = join(map(s:split(line), 's:escape(v:val, esc) . delim . directive'), ', ')
   call setline('.', indent . prefix . format . middle . line . suffix)
   normal! ^f%
 endfunction

--- a/tests/printf.vim
+++ b/tests/printf.vim
@@ -4,6 +4,7 @@ set nocp
 function! s:test(line, exp, ...) abort
   new
   if a:0 > 0 | let b:printf_pattern = a:1 | endif
+  if a:0 > 1 | let b:printf_delim = a:2 | endif
   call setline(1, [a:line])
   try
     Printf
@@ -61,6 +62,11 @@ call s:test('x',
 call s:test('x, y',
           \ 'print("x={}, y={}".format(x, y))',
           \ 'print("%{}".format(%s))')
+
+call s:test('x, y',
+          \ 'print("x: {}, y: {}".format(x, y))',
+          \ 'print("%{}".format(%s))',
+          \ ': ')
 
 if len(v:errors) > 0
   call writefile(v:errors, "/dev/stderr")

--- a/tests/printf.vim
+++ b/tests/printf.vim
@@ -58,6 +58,10 @@ call s:test('x',
           \ 'printf("x=%.2f\n", x);',
           \ 'printf("%.2f\n", %s);')
 
+call s:test('x, y',
+          \ 'print("x={}, y={}".format(x, y))',
+          \ 'print("%{}".format(%s))')
+
 if len(v:errors) > 0
   call writefile(v:errors, "/dev/stderr")
   cquit!


### PR DESCRIPTION
An attempt to solve #2. Starting with the simplest solution, allowing
`%{}` to be used as the directive. The percent literal (`%`) will be
stripped of in the formatted string, but I prefer it be present in the
pattern for consistency.

Please give it a try using the pattern below and let me know what you
think:

```vim
autocmd FileType python let b:printf_pattern = 'print("%{}".format(%s))'
```